### PR TITLE
.DAE Model Import Error Messages

### DIFF
--- a/StudioSB/MainForm.cs
+++ b/StudioSB/MainForm.cs
@@ -725,9 +725,13 @@ namespace StudioSB
                 {
                     ioModel = IONET.IOManager.LoadScene(filePath, settings);
                 }
+                catch (ArgumentNullException e)
+                {
+                    throw new ArgumentNullException("This error is usually caused by missing textures. Go to blender, change shading mode to 'Material Preview', and if ur model looks pink, its missing textures.\n Original Error Msg: \n" + e.Message, e);
+                }
                 catch (NullReferenceException e)
                 {
-                    throw new NullReferenceException("Did you make sure to export an Armature along with the Mesh(es)?\nOriginal Message: " + e.Message , e);
+                    throw new NullReferenceException("This error is usually caused by a not exporting an Armature along with the Meshes. \nOriginal Message: \n" + e.Message , e);
                 }
 
                 SBScene scene;

--- a/StudioSB/MainForm.cs
+++ b/StudioSB/MainForm.cs
@@ -720,7 +720,15 @@ namespace StudioSB
 
             if (Result == DialogResult.OK)
             {
-                var ioModel = IONET.IOManager.LoadScene(filePath, settings);
+                IONET.Core.IOScene ioModel;
+                try
+                {
+                    ioModel = IONET.IOManager.LoadScene(filePath, settings);
+                }
+                catch (NullReferenceException e)
+                {
+                    throw new NullReferenceException("Did you make sure to export an Armature along with the Mesh(es)?\nOriginal Message: " + e.Message , e);
+                }
 
                 SBScene scene;
                 if (loadedScene == null)


### PR DESCRIPTION
Add Error Messages for two common exceptions thrown by IONET due to .dae files missing armatures or having invalid materials.